### PR TITLE
Add cstring header. 

### DIFF
--- a/scm_gl_core/src/scm/gl_core/buffer_objects/uniform_buffer_adaptor.inl
+++ b/scm_gl_core/src/scm/gl_core/buffer_objects/uniform_buffer_adaptor.inl
@@ -4,6 +4,7 @@
 
 #include <cassert>
 #include <iostream>
+#include <cstring>
 
 #include <scm/gl_core/buffer_objects.h>
 #include <scm/gl_core/render_device.h>


### PR DESCRIPTION
After upgrading to g++-4.8, the compiler was complaining:

uniform_buffer_adaptor.inl:109:64: error: ‘memcpy’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation
